### PR TITLE
[store] 修复删除 Http 插件异常报错问题

### DIFF
--- a/store/plugins/store-tool-uploader/src/main/java/modelengine/jade/store/tool/upload/service/impl/PluginUploadServiceImpl.java
+++ b/store/plugins/store-tool-uploader/src/main/java/modelengine/jade/store/tool/upload/service/impl/PluginUploadServiceImpl.java
@@ -173,8 +173,8 @@ public class PluginUploadServiceImpl implements PluginUploadService {
             return 0;
         }
         this.pluginService.deletePlugin(pluginId);
-        if (pluginData.getExtension().get(PROPERTIES_TYPE) != null
-                && pluginData.getExtension().get(PROPERTIES_TYPE) != HTTP) {
+        Object type = pluginData.getExtension().get(PROPERTIES_TYPE);
+        if (type != null && !Objects.equals(type, HTTP)) {
             String toolName = objToString(pluginData.getExtension().get(PLUGIN_FULL_NAME));
             Path toolPath = toolName.endsWith(JAR) ? Paths.get(TOOL_PATH, JAVA) : Paths.get(TOOL_PATH, PYTHON);
             Path deployPath = Paths.get(toolPath.toString(), toolName);


### PR DESCRIPTION
删除Http插件报错，定位原因是type类型为HTTP插件会删除文件（本身不存在），需要检测插件类型为HTTP插件时，跳过删除源文件操作。