### PR TITLE
[app-builder] 增加 StaticResourceFilter 过滤器是否启用的开关

### DIFF
--- a/common/plugins/http-interceptor/src/main/resources/application.yml
+++ b/common/plugins/http-interceptor/src/main/resources/application.yml
@@ -13,3 +13,6 @@ fit:
           - "/**/s3/file/**"
           - "/**/code/**"
           - "/**/knowledge-manager/**"
+
+filter:
+  static-resource-filter: 'enable'


### PR DESCRIPTION
增加 StaticResourceFilter 过滤器是否启用的开关的能力。当前场景，StaticResourceFilter 过滤器对静态资源设置 header 头，用于处理跨域、iframe等问题。可能会与其他组件有相似的能力，故增加是否启用开关的能力，可以通过配置项使该过滤器不生效