### PR TITLE
[frontend] 清空页面聊天记录时添加报错提示

### DIFF
--- a/app-engine/frontend/src/pages/chatPreview/components/send-editor/components/editor-btn-home.tsx
+++ b/app-engine/frontend/src/pages/chatPreview/components/send-editor/components/editor-btn-home.tsx
@@ -217,8 +217,10 @@ const EditorBtnHome = (props) => {
     dispatch(setUseMemory(checked));
   }
   //点击“新聊天”按钮回调
-  const onClickNewChat = () => {
+  const onClickNewChat = async () => {
     if (isChatRunning()) { return; }
+    const res = await getAppInfo(tenantId, appId);
+    if (res.code !== 0) return;
     dispatch(setChatRunning(false));
     updateChatId(null, storageId)
     dispatch(setChatId(null));


### PR DESCRIPTION
[feature] 应用使能浏览器双开应用开发界面，删除该应用后，点击新聊天清空聊天记录时，添加该应用不存在的报错提示