### PR TITLE
[frontend] 编排节点按钮设置为自适配宽度

### DIFF
--- a/app-engine/frontend/src/pages/addFlow/styles/index.scss
+++ b/app-engine/frontend/src/pages/addFlow/styles/index.scss
@@ -220,6 +220,11 @@
   .ant-input-search>.ant-input-group>.ant-input-group-addon:last-child .ant-input-search-button:not(.ant-btn-primary) {
     margin: 0;
   }
+  #elsa-graph {
+    .ant-btn {
+      min-width: unset;
+    }
+  }
 }
 .debug {
   .debug-header {


### PR DESCRIPTION
编排页面画布按钮基于原设计，不设置最小宽度