### PR TITLE
[frontend] 修改前端依赖的 elsa 路径

### DIFF
--- a/app-engine/frontend/package.json
+++ b/app-engine/frontend/package.json
@@ -58,8 +58,8 @@
     "ajv": "8.17.1"
   },
   "dependencies": {
-    "@fit-elsa/elsa-core": "file:../../framework/elsa/fit-elsa",
-    "@fit-elsa/elsa-react": "file:../../framework/elsa/fit-elsa-react",
+    "@fit-elsa/elsa-core": "file:../../../fit-framework/framework/elsa/fit-elsa",
+    "@fit-elsa/elsa-react": "file:../../../fit-framework/framework/elsa/fit-elsa-react",
     "antd": "4.24.13",
     "axios": "1.7.4",
     "dayjs": "1.11.10",


### PR DESCRIPTION
框架和业务代码分离，下载代码的时候需要将 app-platform 仓和 fit-framework 放在同级目录下，修改前端依赖的 elsa 路径指向框架的 elsa 目录