### PR TITLE
Modify the front-end update logic for the knowledge base graph data

### DIFF
--- a/app-engine/frontend/src/pages/configForm/configUi/components/knowledge-container.tsx
+++ b/app-engine/frontend/src/pages/configForm/configUi/components/knowledge-container.tsx
@@ -74,12 +74,10 @@ const KnowledgeContainer = (props) => {
   const updateKnowledgeOption = (groupId: String, knowledgeConfigId:String) => {
     setGroupId(groupId);
     setKnowledgeConfigId(knowledgeConfigId);
-    if (curGroupValue.current.groupId !== groupId) {
-      curGroupValue.current.groupId = groupId;
-      curGroupValue.current.knowledgeConfigId = knowledgeConfigId;
-      graphOperator.update(groupConfig, curGroupValue.current);
-      updateData();
-    }
+    curGroupValue.current.groupId = groupId;
+    curGroupValue.current.knowledgeConfigId = knowledgeConfigId;
+    graphOperator.update(groupConfig, curGroupValue.current);
+    updateData();
   }
 
   // 更新每一条是否存在


### PR DESCRIPTION
1. Remove the condition that the groupId must be different when updating the knowledge base configuration.