### PR TITLE
[appBuilder] 去掉无用的import引入

### DIFF
--- a/app-knowledge/plugins/knowledge-manager/src/test/java/modelengine/jade/knowledge/KnowledgeControllerTest.java
+++ b/app-knowledge/plugins/knowledge-manager/src/test/java/modelengine/jade/knowledge/KnowledgeControllerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import modelengine.fel.tool.service.ToolGroupService;
 import modelengine.fit.http.client.HttpClassicClientResponse;
 import modelengine.fit.jane.task.gateway.Authenticator;
 import modelengine.fitframework.annotation.Fit;


### PR DESCRIPTION
去掉无用的import 引入："modelengine.fel.tool.service.ToolGroupService;" 这个引入的包位置已经挪走了，由其他提交带入