### PR TITLE
[aipp] Remove HTTPS configuration information from logs

### DIFF
--- a/app-builder/fel/java/fel-community/model-openai/src/main/java/modelengine/fel/community/model/openai/OpenAiModel.java
+++ b/app-builder/fel/java/fel-community/model-openai/src/main/java/modelengine/fel/community/model/openai/OpenAiModel.java
@@ -232,7 +232,6 @@ public class OpenAiModel implements EmbedModel, ChatModel, ImageModel {
                    return value;
                }));
 
-        log.info("Create custom HTTPS config: {}", this.serializer.serialize(custom));
         return this.httpClientFactory.create(HttpClassicClientFactory.Config.builder()
                 .socketTimeout(this.clientConfig.socketTimeout())
                 .connectTimeout(this.clientConfig.connectTimeout())
@@ -246,7 +245,6 @@ public class OpenAiModel implements EmbedModel, ChatModel, ImageModel {
         }
 
         Map<String, Object> custom = buildHttpsConfig(secureConfig);
-        log.info("Create custom HTTPS config: {}", this.serializer.serialize(custom));
         return this.httpClientFactory.create(HttpClassicClientFactory.Config.builder()
                 .socketTimeout(this.clientConfig.socketTimeout())
                 .connectTimeout(this.clientConfig.connectTimeout())


### PR DESCRIPTION
For security reasons, HTTPS configuration information should not be logged.