### PR TITLE
[app-builder] fix clean task_instance_new bug

### DIFF
--- a/app-builder/jane/task-new/src/main/resources/mapper/MetaInstanceMapper.xml
+++ b/app-builder/jane/task-new/src/main/resources/mapper/MetaInstanceMapper.xml
@@ -147,7 +147,7 @@
         task_instance_new
         WHERE
         instance_status != 'RUNNING'
-        AND update_at <![CDATA[ < ]]>
+        AND create_time <![CDATA[ < ]]>
         NOW()::TIMESTAMP - (#{expiredDays} || ' day')::INTERVAL
         LIMIT #{limit};
     </select>


### PR DESCRIPTION
修复清理`task_instance_new `表`update_at`字段字段不存在问题。