### PR TITLE
[app-builder] 头像路径配置化

### DIFF
--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/AppVersion.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/AppVersion.java
@@ -192,6 +192,7 @@ public class AppVersion {
     private final AippFlowDefinitionService aippFlowDefinitionService;
     private final FlowDefinitionService flowDefinitionService;
     private final KnowledgeCenterService knowledgeCenterService;
+    private final String resourcePath;
 
     AppVersion(AppBuilderAppPo data, Dependencies dependencies) {
         this.data = data;
@@ -223,6 +224,7 @@ public class AppVersion {
         this.maxQuestionLen = dependencies.getMaxQuestionLen();
         this.maxUserContextLen = dependencies.getMaxUserContextLen();
         this.knowledgeCenterService = dependencies.getKnowledgeCenterService();
+        this.resourcePath = dependencies.getResourcePath();
     }
 
     /**
@@ -879,7 +881,7 @@ public class AppVersion {
         this.formProperties = AppImExportUtil.getFormProperties(this.config.getConfigProperties());
 
         // 对于有头像的应用数据，需要保存头像文件
-        String iconPath = appDto.getIconPath(contextRoot, context);
+        String iconPath = appDto.getIconPath(contextRoot, this.resourcePath, context);
         if (!StringUtils.isBlank(iconPath)) {
             this.setIcon(iconPath);
             this.uploadedFileManageService.addFileRecord(this.getData().getAppId(), context.getAccount(),

--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/AppVersionFactory.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/AppVersionFactory.java
@@ -68,6 +68,7 @@ public class AppVersionFactory {
     private final Integer maxQuestionLen;
     private final Integer maxUserContextLen;
     private final KnowledgeCenterService knowledgeCenterService;
+    private final String resourcePath;
 
     public AppVersionFactory(AppBuilderFormPropertyRepository formPropertyRepository, AppTaskService appTaskService,
             AppBuilderConfigRepository configRepository, AppBuilderFormRepository formRepository,
@@ -81,7 +82,8 @@ public class AppVersionFactory {
             FlowDefinitionService flowDefinitionService,
             @Value("${app-engine.question.max-length}") Integer maxQuestionLen,
             @Value("${app-engine.user-context.max-length}") Integer maxUserContextLen,
-            KnowledgeCenterService knowledgeCenterService) {
+            KnowledgeCenterService knowledgeCenterService,
+            @Value("${app-engine.resource.path}") String resourcePath) {
         this.formPropertyRepository = formPropertyRepository;
         this.appTaskService = appTaskService;
         this.configRepository = configRepository;
@@ -106,6 +108,7 @@ public class AppVersionFactory {
         this.maxQuestionLen = maxQuestionLen != null ? maxQuestionLen : 20000;
         this.maxUserContextLen = maxUserContextLen != null ? maxUserContextLen : 500;
         this.knowledgeCenterService = knowledgeCenterService;
+        this.resourcePath = resourcePath;
     }
 
     /**
@@ -142,6 +145,7 @@ public class AppVersionFactory {
                 .maxQuestionLen(this.maxQuestionLen)
                 .maxUserContextLen(this.maxUserContextLen)
                 .knowledgeCenterService(this.knowledgeCenterService)
+                .resourcePath(this.resourcePath)
                 .build());
     }
 }

--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/Dependencies.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/Dependencies.java
@@ -67,4 +67,5 @@ public class Dependencies {
     private Integer maxQuestionLen;
     private Integer maxUserContextLen;
     private KnowledgeCenterService knowledgeCenterService;
+    private String resourcePath;
 }

--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/dto/export/AppExportDto.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/dto/export/AppExportDto.java
@@ -46,14 +46,15 @@ public class AppExportDto {
     AppExportFlowGraph flowGraph;
 
     /**
-     * 获取icon路径.
+     * 获取头像文件的路径。
      *
-     * @param contextRoot 请求上下文根
-     * @param context 操作人上下文信息.
-     * @return {@link String} icon路径.
+     * @param contextRoot 表示请求上下文根的 {@link String}。
+     * @param context 表示操作人上下文信息的 {@link String}。
+     * @param resourcePath 表示资源目录的 {@link String}。
+     * @return 表示获取到的头像文件的路径的 {@link String}。
      */
     @JsonIgnore
-    public String getIconPath(String contextRoot, OperationContext context) {
+    public String getIconPath(String contextRoot, String resourcePath, OperationContext context) {
         Object iconAttr = this.app.getAttributes().get("icon");
         String iconContent = iconAttr instanceof Map ? ObjectUtils.cast(
                 ObjectUtils.<Map<String, Object>>cast(iconAttr).get("content")) : StringUtils.EMPTY;
@@ -61,7 +62,11 @@ public class AppExportDto {
             return iconContent;
         }
         String iconExtension = ObjectUtils.cast(ObjectUtils.<Map<String, Object>>cast(iconAttr).get("type"));
-        return AppImExportUtil.saveIconFile(iconContent, iconExtension, context.getTenantId(), contextRoot);
+        return AppImExportUtil.saveIconFile(iconContent,
+                iconExtension,
+                context.getTenantId(),
+                contextRoot,
+                resourcePath);
     }
 
     /**

--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/service/impl/FileServiceImpl.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/service/impl/FileServiceImpl.java
@@ -95,7 +95,7 @@ public class FileServiceImpl implements FileService, CustomResourceHandler {
     private final String formFullPath;
     private final String pathPrefix;
     private final String groupName;
-    private final String resourcePathPrefix;
+    private final String resourceUrlPrefix;
 
     private final HttpClassicClientFactory httpClassicClientFactory;
 
@@ -111,7 +111,7 @@ public class FileServiceImpl implements FileService, CustomResourceHandler {
             @Value("${app-engine.form.temporary-path}") String temporaryPath,
             @Value("${app-engine.form.group-name}") String groupName,
             @Value("${app-engine.form.path}") String formPath,
-            @Value("${app-engine.resource.path-prefix}") String resourcePathPrefix) {
+            @Value("${app-engine.resource.url-prefix}") String resourceUrlPrefix) {
         this.httpClassicClientFactory = httpClassicClientFactory;
         this.imageGenModelUrl = imageGenModelUrl;
         this.imageGenModel = imageGenModel;
@@ -122,7 +122,7 @@ public class FileServiceImpl implements FileService, CustomResourceHandler {
         this.formFullPath = pathPrefix + formPath;
         this.formFullTemporaryPath = pathPrefix + temporaryPath;
         this.groupName = groupName;
-        this.resourcePathPrefix = resourcePathPrefix;
+        this.resourceUrlPrefix = resourceUrlPrefix;
     }
 
     @Override
@@ -326,12 +326,12 @@ public class FileServiceImpl implements FileService, CustomResourceHandler {
     public FileEntity handle(String positionName, HttpClassicServerRequest request,
             HttpClassicServerResponse response) {
         String requestPath = request.path();
-        int urlPathPrefixIndex = requestPath.indexOf(this.resourcePathPrefix);
+        int urlPathPrefixIndex = requestPath.indexOf(this.resourceUrlPrefix);
         if (urlPathPrefixIndex == -1 || requestPath.contains("..")) {
             log.error("Url is invalid. Url={}", requestPath);
             throw new IllegalArgumentException(requestPath);
         }
-        String formPath = requestPath.substring(urlPathPrefixIndex + this.resourcePathPrefix.length());
+        String formPath = requestPath.substring(urlPathPrefixIndex + this.resourceUrlPrefix.length());
         String handledFormFullPath = this.getFormFullPath(formPath);
         Path path = Paths.get(handledFormFullPath);
         if (!path.toFile().exists()) {
@@ -356,7 +356,7 @@ public class FileServiceImpl implements FileService, CustomResourceHandler {
 
     @Override
     public boolean canHandle(String positionName, HttpClassicServerRequest request) {
-        int urlPathPrefixIndex = request.path().indexOf(this.resourcePathPrefix);
+        int urlPathPrefixIndex = request.path().indexOf(this.resourceUrlPrefix);
         return urlPathPrefixIndex != -1;
     }
 

--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/util/AppImExportUtil.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/util/AppImExportUtil.java
@@ -531,16 +531,18 @@ public class AppImExportUtil {
      * @param iconExtension 表示图像类型后缀的 {@link String}。
      * @param tenantId 表示租户 id 的 {@link String}。
      * @param contextRoot 表示请求上下文根的 {@link String}。
+     * @param resourcePath 表示资源目录的 {@link String}。
      * @return 表示构造好的图像的路径，可以存放在 attribute 中的 {@link String}。
      */
-    public static String saveIconFile(String iconContent, String iconExtension, String tenantId, String contextRoot) {
+    public static String saveIconFile(String iconContent, String iconExtension, String tenantId, String contextRoot,
+            String resourcePath) {
         boolean isValidExtension = Stream.of(LEGAL_ICON_TYPE)
                 .anyMatch(type -> StringUtils.equalsIgnoreCase(type, iconExtension));
         if (!isValidExtension) {
             return StringUtils.EMPTY;
         }
         String newFileName = UUIDUtil.uuid() + "." + iconExtension;
-        File iconFile = Paths.get(NAS_SHARE_DIR, newFileName).toFile();
+        File iconFile = Paths.get(resourcePath, newFileName).toFile();
         byte[] iconBytes = iconContent.getBytes(StandardCharsets.UTF_8);
         try (InputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(iconBytes))) {
             FileUtils.copyInputStreamToFile(inputStream, iconFile);

--- a/app-builder/jane/plugins/aipp-plugin/src/main/resources/application-prod.yml
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/resources/application-prod.yml
@@ -38,7 +38,8 @@ app-engine:
   exclude-names:
     - 'i18n_appBuilder_*demo*'
   resource:
-    path-prefix: /static/
+    url-prefix: /static/
+    path: /var/share
   form:
     create:
       maximumNum: 400

--- a/app-builder/jane/plugins/aipp-plugin/src/test/java/modelengine/fit/jober/aipp/domains/appversion/AppVersionTest.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/test/java/modelengine/fit/jober/aipp/domains/appversion/AppVersionTest.java
@@ -197,7 +197,7 @@ public class AppVersionTest {
                 this.aippModelCenter,
                 converterFactory,
                 this.aippFlowDefinitionService,
-                this.flowDefinitionService, 20000, 300, this.knowledgeCenterService);
+                this.flowDefinitionService, 20000, 300, this.knowledgeCenterService, "/var/share");
     }
 
     /**

--- a/app-builder/jane/plugins/aipp-plugin/src/test/java/modelengine/fit/jober/aipp/service/AppBuilderAppServiceImplTest.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/test/java/modelengine/fit/jober/aipp/service/AppBuilderAppServiceImplTest.java
@@ -353,7 +353,8 @@ public class AppBuilderAppServiceImplTest {
                 null,
                 20000,
                 300,
-                null);
+                null,
+                "/var/share");
         if (StringUtils.isBlank(appPo.getConfigId())) {
             appPo.setConfigId("defaultConfigId");
         }

--- a/app-builder/jane/plugins/aipp-plugin/src/test/java/modelengine/fit/jober/aipp/util/AppImExportUtilTest.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/test/java/modelengine/fit/jober/aipp/util/AppImExportUtilTest.java
@@ -181,7 +181,8 @@ public class AppImExportUtilTest {
         String iconContent =
                 new String(Base64.getEncoder().encode("This is an icon png.".getBytes(StandardCharsets.UTF_8)),
                         StandardCharsets.UTF_8);
-        String iconUrl = AppImExportUtil.saveIconFile(iconContent, "png", "123", "/api/jober");
+        String tempDir = System.getProperty("java.io.tmpdir");
+        String iconUrl = AppImExportUtil.saveIconFile(iconContent, "png", "123", "/api/jober", tempDir);
         assertThat(iconUrl).startsWith("/api/jober/v1/api/123");
 
         String iconPath = AippFileUtils.getFileNameFromIcon(iconUrl);
@@ -199,10 +200,11 @@ public class AppImExportUtilTest {
         String iconContent =
                 new String(Base64.getEncoder().encode("This is an icon png.".getBytes(StandardCharsets.UTF_8)),
                         StandardCharsets.UTF_8);
-        String iconUrl = AppImExportUtil.saveIconFile(iconContent, "txt", "123", "/api/jober");
+        String tempDir = System.getProperty("java.io.tmpdir");
+        String iconUrl = AppImExportUtil.saveIconFile(iconContent, "txt", "123", "/api/jober", tempDir);
         assertThat(iconUrl).isEqualTo(StringUtils.EMPTY);
 
-        iconUrl = AppImExportUtil.saveIconFile(iconContent, "../../../.jpg", "123", "/api/jober");
+        iconUrl = AppImExportUtil.saveIconFile(iconContent, ".jpg", "123", "/api/jober", tempDir);
         assertThat(iconUrl).isEqualTo(StringUtils.EMPTY);
     }
 


### PR DESCRIPTION
1. 当前保存头像路径时候，是写死在 /var/share 目录下。当前将其改成配置化
2. 部分单测在macos、linux下因为头像路径写死的缘故，无法通过。将其改成临时目录