### PR TITLE
[app-builder]  Disentangle app_suite_id and name

### DIFF
--- a/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/publish/TaskPublisher.java
+++ b/app-builder/jane/plugins/aipp-plugin/src/main/java/modelengine/fit/jober/aipp/domains/appversion/publish/TaskPublisher.java
@@ -62,6 +62,7 @@ public class TaskPublisher implements Publisher {
                 .setAippType(NORMAL.name())
                 .setFlowConfigId(flowInfo.getFlowId())
                 .setFlowDefinitionId(flowInfo.getFlowDefinitionId())
+                .setAppSuiteId(appVersion.getData().getAppSuiteId())
                 .build();
         log.debug("create aipp, task info {}", createArgs.getEntity().toString());
         this.appTaskService.createTask(createArgs, context.getOperationContext());

--- a/app-builder/jane/task-new/src/main/java/modelengine/fit/task_new/repository/impl/MetaRepositoryImpl.java
+++ b/app-builder/jane/task-new/src/main/java/modelengine/fit/task_new/repository/impl/MetaRepositoryImpl.java
@@ -19,6 +19,7 @@ import modelengine.fit.task_new.po.MetaPo;
 import modelengine.fit.task_new.repository.MetaRepository;
 import modelengine.fit.task_new.util.UUIDUtil;
 import modelengine.fitframework.annotation.Component;
+import modelengine.fitframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -43,7 +44,7 @@ public class MetaRepositoryImpl implements MetaRepository {
     @Override
     public Meta insertOne(MetaDeclarationInfo metaDeclarationInfo, OperationContext context) {
         MetaPo metaPO = MetaPo.convertToMetaPO(metaDeclarationInfo, context);
-        String templateId = this.retrieveByName(metaPO.getName()).map(Meta::getId).orElse(UUIDUtil.uuid());
+        String templateId = StringUtils.isNotEmpty(metaPO.getTemplateId()) ? metaPO.getTemplateId() : UUIDUtil.uuid();
         metaPO.setTemplateId(templateId);
         metaPO.setId(UUIDUtil.uuid());
         metaPO.setCreatedBy(context.getOperator());


### PR DESCRIPTION
<!-- 
如果您正在寻求帮助，请先在我们的 QQ 群、微信公众号（群）中进行交流。
If you're looking for help, please check our QQ group, WeChat group.

我们鼓励使用英文，如果不能直接使用，可以使用翻译软件，您仍旧可以保留中文原文。
Please try to use English to describe your issue, or at least provide a snippet of English translation.

请不要在没有创建 Issue 的情况下创建 Pull Request。
Please do not create a Pull Request without creating an issue first.

微小的变更（如错别字修复）不需要创建 Issue。
Trivial changes like typos do not require a Github issue.
-->

## 🔗 相关问题 / Related Issue
<!-- 请先创建 Issue 讨论，然后在这里链接 -->
<!-- Please create an issue for discussion first, then link it here -->

**Issue 链接 / Issue Link:** https://github.com/ModelEngine-Group/app-platform/issues/227

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)  
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change
<!-- 详细描述这个变更的目的和必要性 -->
<!-- Detailed description of the purpose and necessity of this change -->
应用重命名后，可能导致task_new表同一应用的template_id不同。这会导致数据错乱，即同一应用可能出现不同template_id的场景。该变更修复上述问题，将template_id与应用名解绑。
After the application is renamed, the template_id of the same application in the task_new table may be different. This will cause data confusion, that is, the same application may have different template_ids. This change fixes the above problem and unbinds the template_id from the application name.

## 📋 主要变更 / Brief Changelog
<!-- 列出主要的变更内容 -->
<!-- List the main changes -->
1. 修改task_new的数据创建，其template_id直接由appVersion传入，即与应用绑定。而不是查询task_new的name再做处理。
Modify the data creation of task_new, and its template_id is directly passed in from appVersion, that is, it is bound to the application. Instead of querying the name of task_new and then processing it.

## 🧪 验证变更 / Verifying this Change
<!-- 描述如何验证这个变更是正确的 -->
<!-- Describe how to verify that this change is correct -->

### 测试步骤 / Test Steps
1. 创建应用 / Create app
2. 修改应用名，并重新编排 / Modify the application name and rearrange it
3. 此时查看task_new表，出现的同一应用不同task，其template_id相同 / Check the task_new table now, and you will see different tasks for the same application with the same template_id
4. 发布后，发布时task_new创建的数据的template_id，也与1、2步骤创建的数据的template_id相同 / After publishing, the template_id of the data created by task_new during publishing is also the same as the template_id of the data created in steps 1 and 2

### 测试覆盖 / Test Coverage
- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots
<!-- 如果适用，请添加截图来展示变更效果 -->
<!-- If applicable, add screenshots to demonstrate the changes -->

## ✅ 贡献者检查清单 / Contributor Checklist
请确保你的 Pull Request 符合以下要求 / Please ensure your Pull Request meets the following requirements:

**基本要求 / Basic Requirements:**
- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**
- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**
- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 基础检查通过：`mvn -B clean package -Dmaven.test.skip=true` / Basic checks pass
- [x] 单元测试通过：`mvn clean install` / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**
- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes
<!-- 任何其他相关信息，如已知问题、后续计划等 -->
<!-- Any other relevant information, such as known issues, future plans, etc. -->

---

**审查者注意事项 / Reviewer Notes:**
<!-- 为审查者提供的特殊说明或需要重点关注的地方 -->
<!-- Special instructions for reviewers or areas that need special attention -->
